### PR TITLE
Fix: Make SubCommands as KV array

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ const CLAP_JSON: &'static str = r#"{
 "version" : "1.0" , 
 "author" : "json_tester", 
 "about" : "test-clap-serde", 
-"subcommands" : {
-    "sub1" : {"about" : "subcommand_1"},
-    "sub2" : {"about" : "subcommand_2"}
-},
+"subcommands" : [
+    { "sub1" : {"about" : "subcommand_1"}},
+    { "sub2" : {"about" : "subcommand_2"}}
+],
 "args" : [
     { "apple" : {"short" : "a" } },
     { "banana" : {"short" : "b", "long" : "banana", "aliases" : [ "musa_spp" ]} }
@@ -52,7 +52,7 @@ const CLAP_JSON: &'static str = r#"{
 }
 }"#;
 
-let app: clap::App = serde_json::from_str::<clap_serde::AppWrap>(CLAP_JSON)
+let app: clap::App = serde_json::from_str::<clap_serde::CommandWrap>(CLAP_JSON)
     .expect("parse failed")
     .into();
 assert_eq!(app.get_name(), "app_clap_serde");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -35,9 +35,9 @@ args:
 
 subcommands:
     - sub1: 
-        - about : subcommand_1
+        about : subcommand_1
     - sub2: 
-        - about : subcommand_2
+        about : subcommand_2
 
 setting: trailing_var_arg
 
@@ -121,10 +121,10 @@ fn subcommands_json() {
         "version" : "1.0" , 
         "author" : "aobat", 
         "about" : "test-clap-serde", 
-        "subcommands" : {
-            "sub1" : {"about" : "subcommand_1"},
-            "sub2" : {"about" : "subcommand_2"}
-        }}"#;
+        "subcommands" : [
+            {"sub1" : {"about" : "subcommand_1"}},
+            {"sub2" : {"about" : "subcommand_2"}}
+        ]}"#;
     let app: Command = serde_json::from_str::<CommandWrap>(CLAP_JSON)
         .expect("parse failed")
         .into();


### PR DESCRIPTION
#24 
Args was changed in #32, but subcommands wasn't.