### PR TITLE
More Clap 3.2 support 

### DIFF
--- a/src/de/arg/arg_action.rs
+++ b/src/de/arg/arg_action.rs
@@ -1,0 +1,19 @@
+use clap::ArgAction;
+use serde::Deserialize;
+
+enum_de!(ArgAction, ArgAction1,
+    #[derive(Deserialize, Clone, Copy)]
+    #[cfg_attr(feature = "kebab-case-key" ,serde(rename_all = "kebab-case"))]
+    #[cfg_attr(feature = "snake-case-key" ,serde(rename_all = "snake_case"))]
+    {
+        Set,
+        Append,
+        StoreValue,
+        IncOccurrence,
+        SetTrue,
+        SetFalse,
+        Count,
+        Help,
+        Version,
+    }
+);

--- a/src/de/arg/arg_action.rs
+++ b/src/de/arg/arg_action.rs
@@ -1,7 +1,7 @@
-use clap::ArgAction;
+use clap::ArgAction as AA;
 use serde::Deserialize;
 
-enum_de!(ArgAction, ArgAction1,
+enum_de!(AA, ArgAction,
     #[derive(Deserialize, Clone, Copy)]
     #[cfg_attr(feature = "kebab-case-key" ,serde(rename_all = "kebab-case"))]
     #[cfg_attr(feature = "snake-case-key" ,serde(rename_all = "snake_case"))]

--- a/src/de/arg/mod.rs
+++ b/src/de/arg/mod.rs
@@ -1,4 +1,4 @@
-use self::{arg_action::ArgAction1, value_hint::ValueHintSeed, value_parser::ValueParser1};
+use self::{arg_action::ArgAction, value_hint::ValueHint, value_parser::ValueParser};
 use crate::ArgWrap;
 use clap::{Arg, Command};
 use serde::de::{DeserializeSeed, Error, Visitor};
@@ -219,7 +219,7 @@ impl<'a> Visitor<'a> for ArgVisitor<'a> {
                 // },
                 specialize:[
                     "arg_action" => {
-                        arg.action(map.next_value::<ArgAction1>()?.into())
+                        arg.action(map.next_value::<ArgAction>()?.into())
                     }
                     "env" => {
                         #[cfg(env)] { parse_value_inner!(arg, map, Arg, &str, env) }
@@ -231,10 +231,10 @@ impl<'a> Visitor<'a> for ArgVisitor<'a> {
                         #[cfg(env)] { parse_value_inner!(arg, map, Arg, bool, hide_env_values) }
                         #[cfg(not(env))] { return Err(Error::custom("env feature disabled"))}}
                     "value_hint" => {
-                        arg.value_hint(map.next_value_seed(ValueHintSeed)?)
+                        arg.value_hint(map.next_value::<ValueHint>()?.into())
                     }
                     "value_parser" => {
-                        arg.value_parser(map.next_value::<ValueParser1>()?)
+                        arg.value_parser(map.next_value::<ValueParser>()?)
                     }
                 ]
             );

--- a/src/de/arg/mod.rs
+++ b/src/de/arg/mod.rs
@@ -1,9 +1,10 @@
-use self::value_hint::ValueHintSeed;
-use crate::{de::arg::value_parser::ValueParser1, ArgWrap};
+use self::{arg_action::ArgAction1, value_hint::ValueHintSeed, value_parser::ValueParser1};
+use crate::ArgWrap;
 use clap::{Arg, Command};
 use serde::de::{DeserializeSeed, Error, Visitor};
 use std::marker::PhantomData;
 
+mod arg_action;
 mod value_hint;
 mod value_parser;
 
@@ -102,6 +103,7 @@ impl<'a> Visitor<'a> for ArgVisitor<'a> {
 
         while let Some(key) = map.next_key::<&str>()? {
             arg = parse_value!(key, arg, map, Arg, {
+                    // action : specailized
                     (alias, &str),
                     ref (aliases, Vec<&str>),
                     (allow_hyphen_values, bool),
@@ -174,7 +176,7 @@ impl<'a> Visitor<'a> for ArgVisitor<'a> {
                     (value_delimiter, char),
                     (value_name, &str),
                     ref (value_names, Vec<&str>),
-                    // value_parser
+                    // value_parser : specialized
                     (value_terminator, &str),
                     (visible_alias, &str),
                     ref (visible_aliases, Vec<&str>),
@@ -216,6 +218,9 @@ impl<'a> Visitor<'a> for ArgVisitor<'a> {
                 // not_supported: {
                 // },
                 specialize:[
+                    "arg_action" => {
+                        arg.action(map.next_value::<ArgAction1>()?.into())
+                    }
                     "env" => {
                         #[cfg(env)] { parse_value_inner!(arg, map, Arg, &str, env) }
                         #[cfg(not(env))] { return Err(Error::custom("env feature disabled"))}}

--- a/src/de/arg/mod.rs
+++ b/src/de/arg/mod.rs
@@ -64,7 +64,9 @@ impl<'de> Visitor<'de> for ArgKV<'de> {
     where
         A: serde::de::MapAccess<'de>,
     {
-        let name: &str = map.next_key()?.ok_or(A::Error::missing_field("argument"))?;
+        let name: &str = map
+            .next_key()?
+            .ok_or_else(|| A::Error::missing_field("argument"))?;
         map.next_value_seed(ArgVisitor::new_str(name))
     }
 }

--- a/src/de/arg/value_hint.rs
+++ b/src/de/arg/value_hint.rs
@@ -1,7 +1,7 @@
-use clap::ValueHint;
-use serde::{de::DeserializeSeed, Deserialize};
+use clap::ValueHint as VH;
+use serde::Deserialize;
 
-enum_de!(ValueHint,ValueHint1,
+enum_de!(VH,ValueHint,
     #[derive(Deserialize, Clone, Copy)]
     #[cfg_attr(feature = "kebab-case-key" ,serde(rename_all = "kebab-case"))]
     #[cfg_attr(feature = "snake-case-key" ,serde(rename_all = "snake_case"))]
@@ -20,16 +20,3 @@ enum_de!(ValueHint,ValueHint1,
     Url,
     EmailAddress,
 });
-
-pub struct ValueHintSeed;
-
-impl<'de> DeserializeSeed<'de> for ValueHintSeed {
-    type Value = ValueHint;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        ValueHint1::deserialize(deserializer).map(|v| v.into())
-    }
-}

--- a/src/de/arg/value_parser.rs
+++ b/src/de/arg/value_parser.rs
@@ -29,7 +29,7 @@ macro_rules! enum_de_value {
                     min: Option<$pty>,
                     #[serde(skip_serializing_if = "Option::is_none")]
                     max: Option<$pty>,
-                    #[serde(default)]
+                    #[serde(default = "get_true")]
                     max_inclusive: bool
                 } => {
                     match (min, max, max_inclusive) {
@@ -45,6 +45,8 @@ macro_rules! enum_de_value {
         );
     };
 }
+
+const fn get_true() -> bool {true}
 
 enum_de_value!(VP, ValueParser1,
     #[derive(Deserialize, Clone, Copy)]

--- a/src/de/arg/value_parser.rs
+++ b/src/de/arg/value_parser.rs
@@ -28,13 +28,17 @@ macro_rules! enum_de_value {
                     #[serde(skip_serializing_if = "Option::is_none")]
                     min: Option<$pty>, 
                     #[serde(skip_serializing_if = "Option::is_none")]
-                    max: Option<$pty>
+                    max: Option<$pty>,
+                    #[serde(default)]
+                    max_inclusive: bool
                 } => {
-                    match (min, max) {
-                        (Some(s), Some(e)) => clap::value_parser!($pty).range((s $(as $ty_as)*) ..(e $(as $ty_as)*)).into(),
-                        (Some(s), None) => clap::value_parser!($pty).range((s $(as $ty_as)*)..).into(),
-                        (None, Some(e)) => clap::value_parser!($pty).range(..(e $(as $ty_as)*)).into(),
-                        (None, None) => clap::value_parser!($pty).into(),
+                    match (min, max, max_inclusive) {
+                        (Some(s), Some(e), false) => clap::value_parser!($pty).range((s $(as $ty_as)*) ..(e $(as $ty_as)*)).into(),
+                        (Some(s), Some(e), true) => clap::value_parser!($pty).range((s $(as $ty_as)*) ..=(e $(as $ty_as)*)).into(),
+                        (Some(s), None, _) => clap::value_parser!($pty).range((s $(as $ty_as)*)..).into(),
+                        (None, Some(e), false) => clap::value_parser!($pty).range(..(e $(as $ty_as)*)).into(),
+                        (None, Some(e), true) => clap::value_parser!($pty).range(..=(e $(as $ty_as)*)).into(),
+                        (None, None, _) => clap::value_parser!($pty).into(),
                     }
                 },)*
             }

--- a/src/de/arg/value_parser.rs
+++ b/src/de/arg/value_parser.rs
@@ -1,11 +1,52 @@
 use clap::builder::ValueParser;
 use serde::Deserialize;
 
-enum_de!(ValueParser, ValueParser1,
+macro_rules! enum_de_value {
+    ($basety : ident, $newty :ident,
+        $(#[$derive_meta:meta])* 
+        {
+            $( $(
+                #[ $cfg_meta_ex:meta ] )?
+                $var_ex: ident $( { $( $(#[$cfg_v:meta])* $vx: ident : $vt: ty ),* } )?
+                    => $to_ex: expr
+            ,)*
+        }
+        {
+            $(($pty: ty, $pty_upper : tt $(, $ty_as: ty)?)),*
+        }
+    ) => {
+        enum_de!($basety, $newty, 
+            $(#[$derive_meta])* {}
+            {
+                $( $(
+                    #[ $cfg_meta_ex ] )?
+                    $var_ex $( { $( $(#[$cfg_v])* $vx : $vt ),* } )?
+                        => $to_ex
+                ,)*
+                $(
+                $pty_upper {
+                    #[serde(skip_serializing_if = "Option::is_none")]
+                    min: Option<$pty>, 
+                    #[serde(skip_serializing_if = "Option::is_none")]
+                    max: Option<$pty>
+                } => {
+                    match (min, max) {
+                        (Some(s), Some(e)) => clap::value_parser!($pty).range((s $(as $ty_as)*) ..(e $(as $ty_as)*)).into(),
+                        (Some(s), None) => clap::value_parser!($pty).range((s $(as $ty_as)*)..).into(),
+                        (None, Some(e)) => clap::value_parser!($pty).range(..(e $(as $ty_as)*)).into(),
+                        (None, None) => clap::value_parser!($pty).into(),
+                    }
+                },)*
+            }
+        );
+    };
+}
+
+enum_de_value!(ValueParser, ValueParser1, 
     #[derive(Deserialize, Clone, Copy)]
+    #[serde(tag = "type")]
     #[cfg_attr(feature = "kebab-case-key" ,serde(rename_all = "kebab-case"))]
     #[cfg_attr(feature = "snake-case-key" ,serde(rename_all = "snake_case"))]
-    { }
     {
         Bool => {
             ValueParser::bool()
@@ -28,20 +69,16 @@ enum_de!(ValueParser, ValueParser1,
         NonEmptyString => {
             clap::builder::NonEmptyStringValueParser::new().into()
         },
-        RangedI64(s : i64 , e : i64) => {
-            (s..e).into()
-        },
-        RangedInclusizeI64(s : i64 , e : i64) => {
-            (s..=e).into()
-        },
-        RangedFromI64(s : i64) => {
-            (s..).into()
-        },
-        RangedToI64(e : i64) => {
-            (..e).into()
-        },
-        RangedToInclusizeI64(e : i64) => {
-            (..=e).into()
-        },
+    }
+    {
+        (i64, I64),
+        (i32, I32, i64),
+        (i16, I16, i64),
+        (i8 , I8, i64),
+        (u64, U64),
+        (u32, U32, i64),
+        (u16, U16, i64),
+        (u8 , U8, i64)
     }
 );
+

--- a/src/de/arg/value_parser.rs
+++ b/src/de/arg/value_parser.rs
@@ -46,7 +46,9 @@ macro_rules! enum_de_value {
     };
 }
 
-const fn get_true() -> bool {true}
+const fn get_true() -> bool {
+    true
+}
 
 enum_de_value!(VP, ValueParser1,
     #[derive(Deserialize, Clone, Copy)]

--- a/src/de/macros.rs
+++ b/src/de/macros.rs
@@ -99,7 +99,7 @@ macro_rules! enum_de {
         $({
             $( $(
                 #[ $cfg_meta_ex:meta ] )?
-                $var_ex: ident $( ( $( $vx: ident : $vt: ty ),* ) )?
+                $var_ex: ident $( { $( $(#[$cfg_v:meta])* $vx: ident : $vt: ty ),* } )?
                     => $to_ex: expr
             ,)*
         } )?
@@ -108,7 +108,7 @@ macro_rules! enum_de {
         $(#[$derive_meta])*
         pub(crate) enum $newty {
             $(  $(#[$cfg_meta])* $var , )*
-            $($(  $(#[$cfg_meta_ex])* $var_ex $( ( $( $vt ,)* ) )* , )*)*
+            $($(  $(#[$cfg_meta_ex])* $var_ex $( { $( $( #[$cfg_v] )* $vx :  $vt ,)* } )* , )*)*
         }
 
         impl From<$newty> for $basety {
@@ -120,7 +120,7 @@ macro_rules! enum_de {
                     )*
                     $($(
                         $(#[$cfg_meta_ex])*
-                        $newty::$var_ex$(($( $vx ,)*))* => { $to_ex },
+                        $newty::$var_ex$({$( $vx ,)*})* => { $to_ex },
                     )*)*
                 }
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -66,7 +66,8 @@ author : yaml_supporter
 args:
     - apple : 
         short: a
-        value_parser: non_empty_string
+        value_parser: 
+            type: non_empty_string
     - banana:
         short: b
         long: banana

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -71,6 +71,7 @@ args:
     - banana:
         short: b
         long: banana
+        value_parser: non_empty_string
 "#;
 
     let app: CommandWrap = serde_yaml::from_str(CLAP_YAML).expect("fail to make yaml");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -67,7 +67,10 @@ args:
     - apple : 
         short: a
         value_parser: 
-            type: non_empty_string
+            type: i64
+            min: -100
+            max: 100
+            max_inclusive: true
     - banana:
         short: b
         long: banana
@@ -78,13 +81,14 @@ args:
     assert_eq!(app.get_name(), "app_clap_serde");
 
     let args = app.get_arguments().collect::<Vec<_>>();
-    let vp: ValueParser = clap::builder::NonEmptyStringValueParser::default().into();
+    let vp_i: ValueParser = clap::value_parser!(i64).into();
+    let vp_s: ValueParser = clap::builder::NonEmptyStringValueParser::default().into();
     assert!(args.iter().any(|x| x.get_id() == "apple"
         && x.get_short() == Some('a')
-        && x.get_value_parser().type_id() == vp.type_id()));
+        && x.get_value_parser().type_id() == vp_i.type_id()));
     assert!(args.iter().any(|x| x.get_id() == "banana"
         && x.get_short() == Some('b')
-        && x.get_long() == Some("banana")));
+        && x.get_value_parser().type_id() == vp_s.type_id()));
 }
 
 #[test]


### PR DESCRIPTION
Add support of `ArgAction` and more types for `ValueParser` that was missing in #42.